### PR TITLE
Fix menu item removal in terminate method

### DIFF
--- a/addon/globalPlugins/addonsHelp/__init__.py
+++ b/addon/globalPlugins/addonsHelp/__init__.py
@@ -128,9 +128,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# This terminate function is necessary when creating new menus.
 		try:
 			if wx.version().startswith("4"):
-				self.hlpMenu.Remove(self.addonHelpMenu)
+				self.hlpMenu.Remove(self.addonHelpSubMenu)
 			else:
-				self.hlpMenu.RemoveItem(self.addonHelpMenu)
+				self.hlpMenu.RemoveItem(self.addonHelpSubMenu)
+		except:
+			pass
+		try:
+			if wx.version().startswith("4"):
+				self.hlpMenu.Remove(self.disabledAddonHelpSubMenu)
+			else:
+				self.hlpMenu.RemoveItem(self.disabledAddonHelpSubMenu)
 		except:
 			pass
 


### PR DESCRIPTION
Hello Rui

Here is a PR correcting the following bug:

Steps to reproduce:
- Open NVDA
- Ensure to have some addons enabled and others disabled.
- Press NVDA+Ctrl+F3
- Look at the "Running add-ons documentation" and "Disabled add-ons documentation" items in the NVDA -> Tools menu.

Expected behaviour:
Only one of each item is present in the menu

Actual behaviour:
2 items labelled "Running add-ons documentation" are present.
2 items labllled "Disabled add-ons documentation" are present.

Regards,

Cyrille