### PR TITLE
Doc style sheet: Remove inverted color scheme, as done in May 2021 in he add-on template

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,6 @@
 ﻿@charset "utf-8";
 body { 
 font-family : Verdana, Arial, Helvetica, Sans-serif;
-color : #FFFFFF;
-background-color : #000000;
 line-height: 1.2em;
 } 
 h1, h2 {text-align: center}
@@ -26,5 +24,3 @@ a { text-decoration : underline;
 text-decoration : none; 
 }
 a:focus, a:hover {outline: solid}
-:link {color: #0000FF;
-background-color: #FFFFFF}


### PR DESCRIPTION
Will be a benefit for visually impaired people.

For more information, see
https://github.com/nvdaaddons/AddonTemplate/issues/4
and
https://github.com/nvdaaddons/AddonTemplate/pull/8

While at it, if not already done, could you also implement this change in Systray add-on and maybe other add-ons that you maintain)?